### PR TITLE
Implement Admin Mode: restrict registration to teachers with login

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+[
+  {"username": "teacher1", "password": "password123"},
+  {"username": "teacher2", "password": "letmein456"}
+]


### PR DESCRIPTION
This PR implements Admin Mode by requiring teachers to log in (credentials in teachers.json) to register or unregister students for activities. Students can still view activities and participants.